### PR TITLE
Address unsafe publication to volatiles used to form the schema (#3951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * #3873: Require TLSv1.2 or newer for external TLS endpoints
 * #3867: Add addition checks for router mesh status
 #      : Address CRD now validates the spec.address field comprises permitted characters.
+# #3949: Address unsafe publication to volatiles used to form the schema
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes

--- a/api-model/src/main/java/io/enmasse/address/model/AddressTypeInformation.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressTypeInformation.java
@@ -77,6 +77,15 @@ public class AddressTypeInformation {
         return Objects.hash(name, description, plans);
     }
 
+    @Override
+    public String toString() {
+        return "AddressTypeInformation{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", plans=" + plans +
+                '}';
+    }
+
     public static AddressTypeInformation fromAddressType(final AddressType addressType) {
         if (addressType == null) {
             return null;

--- a/api-model/src/main/java/io/enmasse/address/model/Schema.java
+++ b/api-model/src/main/java/io/enmasse/address/model/Schema.java
@@ -130,4 +130,14 @@ public class Schema {
         builder.append("}");
         return builder.toString();
     }
+
+    @Override
+    public String toString() {
+        return "Schema{" +
+                "addressSpaceTypes=" + addressSpaceTypes +
+                ", authenticationServices=" + authenticationServices +
+                ", consoleServices=" + consoleServices +
+                ", creationTimestamp='" + creationTimestamp + '\'' +
+                '}';
+    }
 }

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
@@ -294,32 +294,44 @@ public class KubeSchemaApi implements SchemaApi {
     public Watch watchSchema(Watcher<Schema> watcher, Duration resyncInterval) {
         List<Watch> watches = new ArrayList<>();
         watches.add(addressSpacePlanApi.watchResources(items -> {
-            currentAddressSpacePlans = items;
+            synchronized (KubeSchemaApi.this) {
+                currentAddressSpacePlans = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 
         watches.add(addressPlanApi.watchResources(items -> {
-            currentAddressPlans = items;
+            synchronized (KubeSchemaApi.this) {
+                currentAddressPlans = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 
         watches.add(brokeredInfraConfigApi.watchResources(items -> {
-            currentBrokeredInfraConfigs = items;
+            synchronized (KubeSchemaApi.this) {
+                currentBrokeredInfraConfigs = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 
         watches.add(standardInfraConfigApi.watchResources(items -> {
-            currentStandardInfraConfigs = items;
+            synchronized (KubeSchemaApi.this) {
+                currentStandardInfraConfigs = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 
         watches.add(authenticationServiceApi.watchResources(items -> {
-            currentAuthenticationServices = items;
+            synchronized (KubeSchemaApi.this) {
+                currentAuthenticationServices = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 
         watches.add(consoleServiceApi.watchResources(items -> {
-            currentConsoleServices = items;
+            synchronized (KubeSchemaApi.this) {
+                currentConsoleServices = items;
+            }
             updateSchema(watcher);
         }, resyncInterval));
 


### PR DESCRIPTION
* Fix #3949: Address unsafe publication to volatiles used to form the schema

(the code was reading from currentAddressSpacePlans etc whilst holding the mutex, but the write was made without.  Other threads (the other watching threads were seeing stale values).

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
