### PR TITLE
Fix #4044: Ensure that agent uses bidirection idle-time-out on all AM…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 1.0.0
+
+* #4044: Ensure agent uses bi-directional AMQP idle-time-out for all connections
+
+
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans
 *  #3686: Add metrics endpoint to controller-managerxs

--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -49,7 +49,7 @@ function start(env) {
                     bind_event(bc, 'connection_stats_retrieved', console_server.connections, 'set');
                     bind_event(address_source, 'addresses_defined', bc);
                     bind_event(bc, 'address_stats_retrieved', address_source, 'check_status');
-                    bc.connect(tls_options.get_client_options({host:env.BROKER_SERVICE_HOST, port:env.BROKER_SERVICE_PORT,username:'console'}));
+                    bc.connect(tls_options.get_client_options({host:env.BROKER_SERVICE_HOST, port:env.BROKER_SERVICE_PORT,username:'console', idle_time_out: 8000}));
                 } else {
                     //assume standard address space for now
                     var StandardStats = require('../lib/standard_stats.js');

--- a/agent/lib/ragent.js
+++ b/agent/lib/ragent.js
@@ -334,6 +334,13 @@ Ragent.prototype.configure_handlers = function () {
     var self = this;
     this.container.on('connection_open', function(context) {
         var product = get_product(context.connection);
+
+        var idleTimeout = 8000;
+        if ('idle_time_out' in context.connection.remote.open && context.connection.remote.open.idle_time_out > 0) {
+            idleTimeout = context.connection.remote.open.idle_time_out;
+        }
+        context.connection.local.open.idle_time_out = idleTimeout;
+
         if (product === 'qpid-dispatch-router') {
             var r = rtr.connected(context.connection);
             log.info('Router connected from ' + r.container_id);


### PR DESCRIPTION
…QP connections. (#4040)

- standard address space: agent <- broker idle frames was absent
- brokered address space: broker -> agent idle frames was absent

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
